### PR TITLE
Fix ART crash during initialization.

### DIFF
--- a/src/java/com/android/internal/telephony/cdma/CDMAPhone.java
+++ b/src/java/com/android/internal/telephony/cdma/CDMAPhone.java
@@ -1413,7 +1413,7 @@ public class CDMAPhone extends PhoneBase {
 
     // Define the pattern/format for carrier specified OTASP number schema.
     // It separates by comma and/or whitespace.
-    private static Pattern pOtaSpNumSchema = Pattern.compile("[,\\s]+");
+    private static Pattern pOtaSpNumSchema = null;
 
     /**
      * The following function checks if a dial string is a carrier specified
@@ -1434,6 +1434,9 @@ public class CDMAPhone extends PhoneBase {
      *     and the code itself is "*2".
      */
     private boolean isCarrierOtaSpNum(String dialStr) {
+        if (pOtaSpNumSchema == null) {
+            pOtaSpNumSchema = Pattern.compile("[,\\s]+");
+        }
         boolean isOtaSpNum = false;
         int sysSelCodeInt = extractSelCodeFromOtaSpNum(dialStr);
         if (sysSelCodeInt == INVALID_SYSTEM_SELECTION_CODE) {


### PR DESCRIPTION
The CDMAPhone has a static member that initializes a regexp pattern.
Unfortunately the java.util.regex.Pattern class is not allowed to be called
during ART bootstrap process which causes a bootloop.

To fix this the initialization has been moved into the only method that
uses this regular expression.

Change-Id: I25519cb5b6aa0eb4586eed2bdcd631e1dba24376
