### PR TITLE
Externally-reported Moderate severity vulnerability in SMS: Apps can …

### DIFF
--- a/src/java/com/android/internal/telephony/SMSDispatcher.java
+++ b/src/java/com/android/internal/telephony/SMSDispatcher.java
@@ -90,8 +90,8 @@ public abstract class SMSDispatcher extends Handler {
     private static final String SEND_NEXT_MSG_EXTRA = "SendNextMsg";
 
     /** Permission required to send SMS to short codes without user confirmation. */
-    private static final String SEND_SMS_NO_CONFIRMATION_PERMISSION =
-            "android.permission.SEND_SMS_NO_CONFIRMATION";
+    private static final String SEND_RESPOND_VIA_MESSAGE_PERMISSION =
+            "android.permission.SEND_RESPOND_VIA_MESSAGE";
 
     private static final int PREMIUM_RULE_USE_SIM = 1;
     private static final int PREMIUM_RULE_USE_NETWORK = 2;
@@ -1132,7 +1132,7 @@ public abstract class SMSDispatcher extends Handler {
             return true;
         }
 
-        if (mContext.checkCallingOrSelfPermission(SEND_SMS_NO_CONFIRMATION_PERMISSION)
+        if (mContext.checkCallingOrSelfPermission(SEND_RESPOND_VIA_MESSAGE_PERMISSION)
                 == PackageManager.PERMISSION_GRANTED) {
             return true;            // app is pre-approved to send to short codes
         } else {


### PR DESCRIPTION
…bypass the SMS short code notification prompt

Bug 22314646

DO NOT MERGE

When android.permission.SEND_SMS_NO_CONFIRMATION was renamed to
android.permission.SEND_RESPOND_VIA_MESSAGE in JB-MR2, the necessary change
in SmsDispatcher was accidentally overlooked.

Change-Id: I2c3aa79da8064e55cec5a786696de519c2bf0b07
